### PR TITLE
Added function to allow multi-dimensional arrays in params

### DIFF
--- a/SagePayAdminApi.class.php
+++ b/SagePayAdminApi.class.php
@@ -56,8 +56,10 @@ class SagePayAdminApi {
 	{
 		$return = "<{$key}>";
 		if (is_array($value)){
-		    foreach ($value as $k => $v) {
-		        $return .= $this->recursiveKeyValue($k, $v);
+		    $newkey = $value['key'];
+		    unset($value['key']);
+		    foreach ($value as $v) {
+		        $return .= $this->recursiveKeyValue($newkey, $v);
 		    }
 		} else {
 		    $return .= $value;


### PR DESCRIPTION
In case anyone is still using this useful wrapper I added the ability to have multi-dimensional arrays in params

Example Command: getTransactionList

``` PHP
$adminapi = new SagePayAdminApi('vendor', 'username', 'password');
$transaction = $adminapi->getTransactionList(
                    array(
                        'startdate' => '01/01/2013 00:00:00',
                        'enddate' => '02/01/2013 00:00:00',
                        'txtypes'=>
                            array(
                                'key'=>'txtype',
                                'AUTHORISE',
                                'AUTHENTICATE'
                            )
                        )
                    );
```
